### PR TITLE
fix: update Descope React sample for SDK v2 and session flow

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "descope-flask",
       "version": "0.1.0",
       "dependencies": {
-        "@descope/react-sdk": "^1.0.3",
+        "@descope/react-sdk": "^2.27.2",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2139,84 +2139,455 @@
         "postcss-selector-parser": "^6.0.10"
       }
     },
-    "node_modules/@descope/core-js-sdk": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-1.0.9.tgz",
-      "integrity": "sha512-e8rHQ+QwzuouSpYT90N/Tt14IcIBF1HcHLDb9H/GUU5x1VOXvZ4Dz0DJ08nPjN3kUoRlqLG8p0MvaKrmJ0B2+g==",
+    "node_modules/@descope/access-key-management-widget": {
+      "version": "0.5.37",
+      "resolved": "https://registry.npmjs.org/@descope/access-key-management-widget/-/access-key-management-widget-0.5.37.tgz",
+      "integrity": "sha512-1nKV7ptps6T9X9V3ggF3Lz7cPWgXsMM8y1JA2XtXtTMPAOEZ1sHdxcLVK0hojjGkH6HM6maNg/dSTj49HuojtA==",
       "dependencies": {
-        "eslint-plugin-jsx-a11y": "6.7.1",
-        "jwt-decode": "3.1.2",
-        "lodash.get": "4.4.2"
+        "@descope/sdk-component-drivers": "0.9.0",
+        "@descope/sdk-helpers": "0.6.0",
+        "@descope/sdk-mixins": "0.16.0",
+        "@descope/web-js-sdk": "1.47.0",
+        "@reduxjs/toolkit": "^2.0.1",
+        "immer": "^10.0.3",
+        "redux": "5.0.1",
+        "redux-thunk": "3.1.0",
+        "reselect": "5.1.1",
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@descope/access-key-management-widget/node_modules/@descope/sdk-mixins": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@descope/sdk-mixins/-/sdk-mixins-0.16.0.tgz",
+      "integrity": "sha512-+mTddi0ISl3YZxadpWyd5Jmme+5JLltloPJt3GMcpUbJ4ELTK1yICwTE/0TXGf5KZAempOXhtxpMCdbweBaFMw==",
+      "dependencies": {
+        "@descope/sdk-component-drivers": "0.9.0",
+        "@descope/sdk-helpers": "0.6.0",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@reduxjs/toolkit": "^2.0.1",
+        "immer": "^10.0.3",
+        "redux": "5.0.1",
+        "redux-thunk": "3.1.0"
+      }
+    },
+    "node_modules/@descope/access-key-management-widget/node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/@descope/applications-portal-widget": {
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@descope/applications-portal-widget/-/applications-portal-widget-0.5.20.tgz",
+      "integrity": "sha512-+B7694O+7xVLvtV0/r2liatsaEg4/ynbMHrtfnJVYHbah3PXAXeeF/zS0zLfymzPv2FjJ9aZo4LuG6pe6r1Adg==",
+      "dependencies": {
+        "@descope/sdk-component-drivers": "0.9.0",
+        "@descope/sdk-helpers": "0.6.0",
+        "@descope/sdk-mixins": "0.16.0",
+        "@descope/web-js-sdk": "1.47.0",
+        "@reduxjs/toolkit": "^2.0.1",
+        "immer": "^10.0.3",
+        "redux": "5.0.1",
+        "redux-thunk": "3.1.0",
+        "reselect": "5.1.1",
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@descope/applications-portal-widget/node_modules/@descope/sdk-mixins": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@descope/sdk-mixins/-/sdk-mixins-0.16.0.tgz",
+      "integrity": "sha512-+mTddi0ISl3YZxadpWyd5Jmme+5JLltloPJt3GMcpUbJ4ELTK1yICwTE/0TXGf5KZAempOXhtxpMCdbweBaFMw==",
+      "dependencies": {
+        "@descope/sdk-component-drivers": "0.9.0",
+        "@descope/sdk-helpers": "0.6.0",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@reduxjs/toolkit": "^2.0.1",
+        "immer": "^10.0.3",
+        "redux": "5.0.1",
+        "redux-thunk": "3.1.0"
+      }
+    },
+    "node_modules/@descope/applications-portal-widget/node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/@descope/audit-management-widget": {
+      "version": "0.5.37",
+      "resolved": "https://registry.npmjs.org/@descope/audit-management-widget/-/audit-management-widget-0.5.37.tgz",
+      "integrity": "sha512-w+d4H0Cq7U/p0VvFTUOIekZCmfihkkb1IVCbc2fN3RPW0VFoU+dg5hZEvBKpXTfeATvThR+AXOKDD0li0FDZrw==",
+      "dependencies": {
+        "@descope/sdk-component-drivers": "0.9.0",
+        "@descope/sdk-helpers": "0.6.0",
+        "@descope/sdk-mixins": "0.16.0",
+        "@descope/web-js-sdk": "1.47.0",
+        "@reduxjs/toolkit": "^2.0.1",
+        "immer": "^10.0.3",
+        "redux": "5.0.1",
+        "redux-thunk": "3.1.0",
+        "reselect": "5.1.1",
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@descope/audit-management-widget/node_modules/@descope/sdk-mixins": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@descope/sdk-mixins/-/sdk-mixins-0.16.0.tgz",
+      "integrity": "sha512-+mTddi0ISl3YZxadpWyd5Jmme+5JLltloPJt3GMcpUbJ4ELTK1yICwTE/0TXGf5KZAempOXhtxpMCdbweBaFMw==",
+      "dependencies": {
+        "@descope/sdk-component-drivers": "0.9.0",
+        "@descope/sdk-helpers": "0.6.0",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@reduxjs/toolkit": "^2.0.1",
+        "immer": "^10.0.3",
+        "redux": "5.0.1",
+        "redux-thunk": "3.1.0"
+      }
+    },
+    "node_modules/@descope/audit-management-widget/node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/@descope/core-js-sdk": {
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@descope/core-js-sdk/-/core-js-sdk-2.58.0.tgz",
+      "integrity": "sha512-apgmtj7J/4kc17WrmzLXp89XGM3aLFLg8HhtPDpAMcUKWAlS0MJ4rlKd6Ab0WRTlUCq7Gm9DUQQgCblX8qMCkA==",
+      "dependencies": {
+        "jwt-decode": "4.0.0"
+      }
+    },
+    "node_modules/@descope/escape-markdown": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@descope/escape-markdown/-/escape-markdown-0.1.6.tgz",
+      "integrity": "sha512-3ENrye8fyyAp88w8OoKGsEl/kH0GgcrPiDRoOajhCODOJnoJ8P/4/giBEjWZV/FKllW4Z5mSXGACEmlINOZLCA=="
+    },
+    "node_modules/@descope/outbound-applications-widget": {
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@descope/outbound-applications-widget/-/outbound-applications-widget-0.2.27.tgz",
+      "integrity": "sha512-8dVJsnpfzgBMu1xzYg7UPTDeSVuXq0WxmlAgvOHtq63vDFnaOLxKKtf5TssEL753QgV0iwyYKXqoKfkmwfSkzw==",
+      "dependencies": {
+        "@descope/sdk-component-drivers": "0.9.0",
+        "@descope/sdk-helpers": "0.6.0",
+        "@descope/sdk-mixins": "0.16.0",
+        "@descope/web-component": "3.58.1",
+        "@descope/web-js-sdk": "1.47.0",
+        "@reduxjs/toolkit": "^2.0.1",
+        "immer": "^10.0.3",
+        "redux": "5.0.1",
+        "redux-thunk": "3.1.0",
+        "reselect": "5.1.1",
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@descope/outbound-applications-widget/node_modules/@descope/sdk-mixins": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@descope/sdk-mixins/-/sdk-mixins-0.16.0.tgz",
+      "integrity": "sha512-+mTddi0ISl3YZxadpWyd5Jmme+5JLltloPJt3GMcpUbJ4ELTK1yICwTE/0TXGf5KZAempOXhtxpMCdbweBaFMw==",
+      "dependencies": {
+        "@descope/sdk-component-drivers": "0.9.0",
+        "@descope/sdk-helpers": "0.6.0",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@reduxjs/toolkit": "^2.0.1",
+        "immer": "^10.0.3",
+        "redux": "5.0.1",
+        "redux-thunk": "3.1.0"
+      }
+    },
+    "node_modules/@descope/outbound-applications-widget/node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@descope/react-sdk": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@descope/react-sdk/-/react-sdk-1.0.3.tgz",
-      "integrity": "sha512-yR1gRF2PaZlespixrR46sricGMn5mbEI3wRU3ea3eOTee3Ejh3W5z+EYuzf8g5T/DvypjXCcKJs5OCRFF2CEBg==",
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/@descope/react-sdk/-/react-sdk-2.27.2.tgz",
+      "integrity": "sha512-S/c8vlYqPBzcWBg9SPnkC3v2cp2oFVOFyjNtPy5lWq3cBTEzYCGO98dddHRTmXHmABxPiTIs9ghEmaD/JVfP0g==",
       "dependencies": {
-        "@descope/web-component": "2.0.14",
-        "react-router-dom": "6.9.0"
+        "@descope/access-key-management-widget": "0.5.37",
+        "@descope/applications-portal-widget": "0.5.20",
+        "@descope/audit-management-widget": "0.5.37",
+        "@descope/core-js-sdk": "2.58.0",
+        "@descope/outbound-applications-widget": "0.2.27",
+        "@descope/role-management-widget": "0.5.29",
+        "@descope/sdk-helpers": "0.6.0",
+        "@descope/tenant-profile-widget": "0.5.27",
+        "@descope/user-management-widget": "0.11.16",
+        "@descope/user-profile-widget": "0.9.11",
+        "@descope/web-component": "3.58.1",
+        "@descope/web-js-sdk": "1.47.0"
       },
       "peerDependencies": {
-        "@descope/web-js-sdk": "1.0.8",
         "@types/react": ">=16",
         "react": ">=16"
       }
     },
-    "node_modules/@descope/react-sdk/node_modules/@remix-run/router": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.4.0.tgz",
-      "integrity": "sha512-BJ9SxXux8zAg991UmT8slpwpsd31K1dHHbD3Ba4VzD+liLQ4WAMSxQp2d2ZPRPfN0jN2NPRowcSSoM7lCaF08Q==",
-      "engines": {
-        "node": ">=14"
+    "node_modules/@descope/role-management-widget": {
+      "version": "0.5.29",
+      "resolved": "https://registry.npmjs.org/@descope/role-management-widget/-/role-management-widget-0.5.29.tgz",
+      "integrity": "sha512-4EGdF8ud1YGbECu1YymcsFGroOhDWmV80GwphaRIz028UeXC4CGRVuIBt/J1vE0LCPFgr1v0t07WG9B1QDG0bQ==",
+      "dependencies": {
+        "@descope/sdk-component-drivers": "0.9.0",
+        "@descope/sdk-helpers": "0.6.0",
+        "@descope/sdk-mixins": "0.16.0",
+        "@descope/web-js-sdk": "1.47.0",
+        "@reduxjs/toolkit": "^2.0.1",
+        "immer": "^10.0.3",
+        "redux": "5.0.1",
+        "redux-thunk": "3.1.0",
+        "reselect": "5.1.1",
+        "tslib": "2.8.1"
       }
     },
-    "node_modules/@descope/react-sdk/node_modules/react-router": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.9.0.tgz",
-      "integrity": "sha512-51lKevGNUHrt6kLuX3e/ihrXoXCa9ixY/nVWRLlob4r/l0f45x3SzBvYJe3ctleLUQQ5fVa4RGgJOTH7D9Umhw==",
+    "node_modules/@descope/role-management-widget/node_modules/@descope/sdk-mixins": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@descope/sdk-mixins/-/sdk-mixins-0.16.0.tgz",
+      "integrity": "sha512-+mTddi0ISl3YZxadpWyd5Jmme+5JLltloPJt3GMcpUbJ4ELTK1yICwTE/0TXGf5KZAempOXhtxpMCdbweBaFMw==",
       "dependencies": {
-        "@remix-run/router": "1.4.0"
-      },
-      "engines": {
-        "node": ">=14"
+        "@descope/sdk-component-drivers": "0.9.0",
+        "@descope/sdk-helpers": "0.6.0",
+        "tslib": "2.8.1"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "@reduxjs/toolkit": "^2.0.1",
+        "immer": "^10.0.3",
+        "redux": "5.0.1",
+        "redux-thunk": "3.1.0"
       }
     },
-    "node_modules/@descope/react-sdk/node_modules/react-router-dom": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.9.0.tgz",
-      "integrity": "sha512-/seUAPY01VAuwkGyVBPCn1OXfVbaWGGu4QN9uj0kCPcTyNYgL1ldZpxZUpRU7BLheKQI4Twtl/OW2nHRF1u26Q==",
+    "node_modules/@descope/role-management-widget/node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/@descope/sdk-component-drivers": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@descope/sdk-component-drivers/-/sdk-component-drivers-0.9.0.tgz",
+      "integrity": "sha512-BYvIQd66vmyXM+uPePGZALIKqaCInrLh++XKiL1xHFjJgd7PQ+74nXkYE2r+VVteXFk0HpVNI7zBx6iejirJwg==",
       "dependencies": {
-        "@remix-run/router": "1.4.0",
-        "react-router": "6.9.0"
+        "@descope/sdk-helpers": "0.6.0",
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@descope/sdk-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@descope/sdk-helpers/-/sdk-helpers-0.6.0.tgz",
+      "integrity": "sha512-0zoIYnGJsJCYcMXdQOWp5j1KUgQfcosoDEtiGMsr4PlQCbWpLme4Ma+OY6DJ/BsMbuFcpbSMzvi2tJyVnMQF1w==",
+      "dependencies": {
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@descope/tenant-profile-widget": {
+      "version": "0.5.27",
+      "resolved": "https://registry.npmjs.org/@descope/tenant-profile-widget/-/tenant-profile-widget-0.5.27.tgz",
+      "integrity": "sha512-n1o2StnBgUOTELQOgP9nXNGVmSaTrFTdNvNWniJdHdvsWpYr7UOwSq4I6LtHR3MnQWqz8Ybg55AKlNWaacWcfg==",
+      "dependencies": {
+        "@descope/sdk-component-drivers": "0.9.0",
+        "@descope/sdk-helpers": "0.6.0",
+        "@descope/sdk-mixins": "0.16.0",
+        "@descope/web-component": "3.58.1",
+        "@descope/web-js-sdk": "1.47.0",
+        "@reduxjs/toolkit": "^2.0.1",
+        "immer": "^10.0.3",
+        "redux": "5.0.1",
+        "redux-thunk": "3.1.0",
+        "reselect": "5.1.1",
+        "tslib": "2.8.1"
       },
-      "engines": {
-        "node": ">=14"
+      "optionalDependencies": {
+        "@descope/core-js-sdk": "2.58.0"
+      }
+    },
+    "node_modules/@descope/tenant-profile-widget/node_modules/@descope/sdk-mixins": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@descope/sdk-mixins/-/sdk-mixins-0.16.0.tgz",
+      "integrity": "sha512-+mTddi0ISl3YZxadpWyd5Jmme+5JLltloPJt3GMcpUbJ4ELTK1yICwTE/0TXGf5KZAempOXhtxpMCdbweBaFMw==",
+      "dependencies": {
+        "@descope/sdk-component-drivers": "0.9.0",
+        "@descope/sdk-helpers": "0.6.0",
+        "tslib": "2.8.1"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "@reduxjs/toolkit": "^2.0.1",
+        "immer": "^10.0.3",
+        "redux": "5.0.1",
+        "redux-thunk": "3.1.0"
+      }
+    },
+    "node_modules/@descope/tenant-profile-widget/node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/@descope/user-management-widget": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@descope/user-management-widget/-/user-management-widget-0.11.16.tgz",
+      "integrity": "sha512-wCd5kwis580iWeOZbLsBJzCMtnB/gryLEaBE9YppSi+of62qMZevcM4xDd39b67GL6k9WVknPhSDgXrZKrzfXw==",
+      "dependencies": {
+        "@descope/sdk-component-drivers": "0.9.0",
+        "@descope/sdk-helpers": "0.6.0",
+        "@descope/sdk-mixins": "0.16.0",
+        "@descope/web-component": "3.58.1",
+        "@descope/web-js-sdk": "1.47.0",
+        "@reduxjs/toolkit": "^2.0.1",
+        "immer": "^10.0.3",
+        "libphonenumber-js": "1.11.17",
+        "redux": "5.0.1",
+        "redux-thunk": "3.1.0",
+        "reselect": "5.1.1",
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@descope/user-management-widget/node_modules/@descope/sdk-mixins": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@descope/sdk-mixins/-/sdk-mixins-0.16.0.tgz",
+      "integrity": "sha512-+mTddi0ISl3YZxadpWyd5Jmme+5JLltloPJt3GMcpUbJ4ELTK1yICwTE/0TXGf5KZAempOXhtxpMCdbweBaFMw==",
+      "dependencies": {
+        "@descope/sdk-component-drivers": "0.9.0",
+        "@descope/sdk-helpers": "0.6.0",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@reduxjs/toolkit": "^2.0.1",
+        "immer": "^10.0.3",
+        "redux": "5.0.1",
+        "redux-thunk": "3.1.0"
+      }
+    },
+    "node_modules/@descope/user-management-widget/node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/@descope/user-profile-widget": {
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/@descope/user-profile-widget/-/user-profile-widget-0.9.11.tgz",
+      "integrity": "sha512-LJoIoEBBLGCmOHN7BlMSP8EiDzWdxxK4dX4RXEn9W+DtFMG9pj01OlDc9RVYi0Omjs7nfFX8EppZJCDBehsKqA==",
+      "dependencies": {
+        "@descope/sdk-component-drivers": "0.9.0",
+        "@descope/sdk-helpers": "0.6.0",
+        "@descope/sdk-mixins": "0.16.0",
+        "@descope/web-component": "3.58.1",
+        "@descope/web-js-sdk": "1.47.0",
+        "@reduxjs/toolkit": "^2.0.1",
+        "immer": "^10.0.3",
+        "redux": "5.0.1",
+        "redux-thunk": "3.1.0",
+        "reselect": "5.1.1",
+        "tslib": "2.8.1"
+      },
+      "optionalDependencies": {
+        "@descope/core-js-sdk": "2.58.0"
+      }
+    },
+    "node_modules/@descope/user-profile-widget/node_modules/@descope/sdk-mixins": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@descope/sdk-mixins/-/sdk-mixins-0.16.0.tgz",
+      "integrity": "sha512-+mTddi0ISl3YZxadpWyd5Jmme+5JLltloPJt3GMcpUbJ4ELTK1yICwTE/0TXGf5KZAempOXhtxpMCdbweBaFMw==",
+      "dependencies": {
+        "@descope/sdk-component-drivers": "0.9.0",
+        "@descope/sdk-helpers": "0.6.0",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@reduxjs/toolkit": "^2.0.1",
+        "immer": "^10.0.3",
+        "redux": "5.0.1",
+        "redux-thunk": "3.1.0"
+      }
+    },
+    "node_modules/@descope/user-profile-widget/node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@descope/web-component": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-2.0.14.tgz",
-      "integrity": "sha512-UZMM1ZhbK4QQ8yWZz0qcRrZ+EBT4q4T75778og4j4YTL2oFbq4vyOBNYegzfvQEEv1uBh9lZB4iq42CMRbf09A==",
+      "version": "3.58.1",
+      "resolved": "https://registry.npmjs.org/@descope/web-component/-/web-component-3.58.1.tgz",
+      "integrity": "sha512-Whr1jb3Dfp/BQiradmNk5GPZgpC5sf9jZvPOvazaODRNZ/tDXpAu9NPqCneUzTDe74hufzMGtZ0XUEqbR/UVGA==",
       "dependencies": {
-        "@descope/web-js-sdk": "1.0.8"
+        "@descope/escape-markdown": "0.1.6",
+        "@descope/sdk-helpers": "0.6.0",
+        "@descope/sdk-mixins": "0.16.0",
+        "@descope/web-js-sdk": "1.47.0",
+        "@fingerprintjs/fingerprintjs-pro": "3.11.6",
+        "tslib": "2.8.1"
+      }
+    },
+    "node_modules/@descope/web-component/node_modules/@descope/sdk-mixins": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@descope/sdk-mixins/-/sdk-mixins-0.16.0.tgz",
+      "integrity": "sha512-+mTddi0ISl3YZxadpWyd5Jmme+5JLltloPJt3GMcpUbJ4ELTK1yICwTE/0TXGf5KZAempOXhtxpMCdbweBaFMw==",
+      "dependencies": {
+        "@descope/sdk-component-drivers": "0.9.0",
+        "@descope/sdk-helpers": "0.6.0",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@reduxjs/toolkit": "^2.0.1",
+        "immer": "^10.0.3",
+        "redux": "5.0.1",
+        "redux-thunk": "3.1.0"
+      }
+    },
+    "node_modules/@descope/web-component/node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@descope/web-js-sdk": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.0.8.tgz",
-      "integrity": "sha512-JZide403B91/PYj1jN2ZO8swXQa9jkjagXE7bBF77k596Db/OhChYRIiQTQyleZdqQYiWxch8XkkoSGgz9Tmhg==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@descope/web-js-sdk/-/web-js-sdk-1.47.0.tgz",
+      "integrity": "sha512-g8HO5AYnaLhzahxNWkuUWytmO+9UdTqJOyvcD92wm6LOrwlzjMQiNtWpjifN6GEKE62+Hf74VgG7Y+0bF9RScw==",
       "dependencies": {
-        "@descope/core-js-sdk": "1.0.9",
-        "@fingerprintjs/fingerprintjs-pro": "3.8.2",
-        "js-cookie": "3.0.1"
+        "@descope/core-js-sdk": "2.58.0",
+        "@fingerprintjs/fingerprintjs-pro": "3.11.6",
+        "js-cookie": "3.0.5",
+        "jwt-decode": "4.0.0",
+        "tslib": "2.8.1"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2313,9 +2684,9 @@
       }
     },
     "node_modules/@fingerprintjs/fingerprintjs-pro": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.8.2.tgz",
-      "integrity": "sha512-cccPaHhzt2AnXbUEdpMW4/19eous5/WJhNlawq5BJKmmGSHJzjjb0kkNXgC0QlFll1YsoqLAxmGLOYRVVfmTBA==",
+      "version": "3.11.6",
+      "resolved": "https://registry.npmjs.org/@fingerprintjs/fingerprintjs-pro/-/fingerprintjs-pro-3.11.6.tgz",
+      "integrity": "sha512-ohN4lorSzV0fzs8fELWuO3bvMMfzF5qyQSOWBvqwGaq6yPP+XSRJOeFdFFiwAqFWYJDEoDOlQluGfa0Rfk7mAQ==",
       "dependencies": {
         "tslib": "^2.4.1"
       }
@@ -3203,6 +3574,40 @@
         }
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.2.tgz",
@@ -3310,6 +3715,16 @@
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -11633,11 +12048,11 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
-      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/js-sdsl": {
@@ -11785,9 +12200,12 @@
       }
     },
     "node_modules/jwt-decode": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
-      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -11855,6 +12273,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.11.17",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.17.tgz",
+      "integrity": "sha512-Jr6v8thd5qRlOlc6CslSTzGzzQW03uiscab7KHQZX1Dfo4R6n6FDhZ0Hri6/X7edLIDv9gl4VMZXhxTjLnl0VQ=="
+    },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -11912,11 +12335,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -14637,6 +15055,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -14762,6 +15193,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
     },
     "node_modules/resolve": {
       "version": "1.22.2",
@@ -16217,9 +16653,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "proxy": "http://127.0.0.1:5000/",
   "dependencies": {
-    "@descope/react-sdk": "^1.0.3",
+    "@descope/react-sdk": "^2.27.2",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/client/src/ConfigError.js
+++ b/client/src/ConfigError.js
@@ -1,0 +1,50 @@
+import React from 'react';
+
+const PLACEHOLDERS = new Set([
+  '',
+  'YOUR_DESCOPE_PROJECT_ID',
+  '__ProjectID__',
+  'your-project-id',
+]);
+
+export function isValidDescopeProjectId(value) {
+  if (typeof value !== 'string') return false;
+  const id = value.trim();
+  if (!id) return false;
+  if (PLACEHOLDERS.has(id)) return false;
+  return true;
+}
+
+export default function ConfigError() {
+  return (
+    <div
+      style={{
+        fontFamily: 'system-ui, sans-serif',
+        maxWidth: 520,
+        margin: '48px auto',
+        padding: 24,
+        lineHeight: 1.5,
+      }}
+    >
+      <h1 style={{ fontSize: '1.25rem' }}>Descope configuration required</h1>
+      <p>
+        Add your project ID to <code style={{ background: '#eee', padding: '2px 6px' }}>client/.env</code>:
+      </p>
+      <pre
+        style={{
+          background: '#f4f4f4',
+          padding: 12,
+          borderRadius: 8,
+          overflow: 'auto',
+        }}
+      >
+        REACT_APP_PROJECT_ID=P2xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      </pre>
+      <p>
+        Use the same value as in the Descope console (Settings → Project). Then stop and restart{' '}
+        <code style={{ background: '#eee', padding: '2px 6px' }}>npm start</code> — Create React App only reads{' '}
+        <code style={{ background: '#eee', padding: '2px 6px' }}>.env</code> at startup.
+      </p>
+    </div>
+  );
+}

--- a/client/src/components/Dashboard.js
+++ b/client/src/components/Dashboard.js
@@ -1,60 +1,93 @@
 import '../App.css';
-import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
-import { useNavigate } from "react-router-dom";
-import { getSessionToken } from '@descope/react-sdk'
-
+import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { getSessionToken, useSession } from '@descope/react-sdk';
 
 function Dashboard() {
-    const sessionToken = getSessionToken(); // get the session token
-    const navigate = useNavigate()
+    const { isSessionLoading, isAuthenticated, sessionToken } = useSession();
+    const navigate = useNavigate();
     const [roles, setRoles] = useState({
         teacherRole: false,
-        studentRole: false
-    })
+        studentRole: false,
+    });
 
     useEffect(() => {
-        fetch('/get_role_data', { // call the api endpoint from the flask server
+        if (isSessionLoading) return;
+        if (!isAuthenticated) {
+            navigate('/login');
+            return;
+        }
+
+        const token = sessionToken || getSessionToken();
+        if (!token) {
+            navigate('/login');
+            return;
+        }
+
+        fetch('/get_role_data', {
             headers: {
                 Accept: 'application/json',
-                Authorization: 'Bearer ' + sessionToken,
-            }
-        }).then(data => {
-            if (data.status === 401) {
-                navigate('/login')
-            }
-            return data.json()
-        }).then(jsonData => {
-            setRoles({
-                teacherRole: jsonData.valid_teacher,
-                studentRole: jsonData.valid_student
-            })
-        }).catch((err) => {
-            console.log(err)
-            navigate('/login')
+                Authorization: `Bearer ${token}`,
+            },
         })
-    }, [])
+            .then((data) => {
+                if (data.status === 401) {
+                    navigate('/login');
+                    return null;
+                }
+                return data.json();
+            })
+            .then((jsonData) => {
+                if (!jsonData) return;
+                setRoles({
+                    teacherRole: jsonData.valid_teacher,
+                    studentRole: jsonData.valid_student,
+                });
+            })
+            .catch(() => {
+                navigate('/login');
+            });
+    }, [isSessionLoading, isAuthenticated, sessionToken, navigate]);
+
+    if (isSessionLoading) {
+        return (
+            <div className="page">
+                <p>Loading...</p>
+            </div>
+        );
+    }
+
+    if (!isAuthenticated) {
+        return null;
+    }
 
     return (
-        <div className='page'>
-            <h1 className='title'>Dashboard</h1>
-            <Link className='link btn' to="/profile">Profile</Link>
+        <div className="page">
+            <h1 className="title">Dashboard</h1>
+            <Link className="link btn" to="/profile">
+                Profile
+            </Link>
             {roles.teacherRole && (
-                <div className='page'>
+                <div className="page">
                     <h1>Welcome back Teacher!</h1>
-                    <p className='students'>You have 50+ students currently 🧑‍🎓</p>
+                    <p className="students">You have 50+ students currently 🧑‍🎓</p>
                 </div>
             )}
             {roles.studentRole && (
-                <div className='page'>
+                <div className="page">
                     <h1>Welcome back Student!</h1>
-                    <p className='student'>Unlucky! You have homework!</p>
-                    <iframe src="https://giphy.com/embed/H9UeFGxZz4cBG" width="469" height="480" allowFullScreen></iframe>
+                    <p className="student">Unlucky! You have homework!</p>
+                    <iframe
+                        title="Homework gif"
+                        src="https://giphy.com/embed/H9UeFGxZz4cBG"
+                        width="469"
+                        height="480"
+                        allowFullScreen
+                    />
                 </div>
             )}
         </div>
-    )
+    );
 }
-
 
 export default Dashboard;

--- a/client/src/components/Home.js
+++ b/client/src/components/Home.js
@@ -1,27 +1,37 @@
 import '../App.css';
-import { useEffect } from "react";
-import { Link } from "react-router-dom";
-import { useSession } from '@descope/react-sdk'
-import { useNavigate } from "react-router-dom";
+import { Link, Navigate } from 'react-router-dom';
+import { useSession } from '@descope/react-sdk';
 
 function Home() {
-    const { isAuthenticated } = useSession()
-    const navigate = useNavigate()
+    const { isAuthenticated, isSessionLoading } = useSession();
 
-    useEffect(() => {
-        if (isAuthenticated) {
-            return navigate("/profile");
-        }
-    }, [isAuthenticated]) // listen for when isAuthenticated has changed
+    if (isSessionLoading) {
+        return (
+            <div className="page">
+                <p>Loading...</p>
+            </div>
+        );
+    }
+
+    if (isAuthenticated) {
+        return <Navigate to="/profile" replace />;
+    }
 
     return (
-        <div className='page'>
-            <h1 className='title'>Home</h1>
-            <Link className='link btn' to="/login">Login</Link>
-            <iframe src="https://giphy.com/embed/bKj0qEKTVBdF2o5Dgn" width="480" height="352" allowFullScreen></iframe>
+        <div className="page">
+            <h1 className="title">Home</h1>
+            <Link className="link btn" to="/login">
+                Login
+            </Link>
+            <iframe
+                title="Welcome animation"
+                src="https://giphy.com/embed/bKj0qEKTVBdF2o5Dgn"
+                width="480"
+                height="352"
+                allowFullScreen
+            />
         </div>
-    )
+    );
 }
-
 
 export default Home;

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -1,45 +1,50 @@
 import '../App.css';
-import React, { useEffect } from "react";
-import { Descope, useSession, useUser } from '@descope/react-sdk'
-import { useNavigate } from "react-router-dom";
-
+import React, { useEffect } from 'react';
+import { Descope, useSession, useUser } from '@descope/react-sdk';
+import { useNavigate } from 'react-router-dom';
 
 function Login() {
-    // isAuthenticated: boolean - is the user authenticated?
-    // isSessionLoading: boolean - Use this for showing loading screens while objects are being loaded
-    const { isAuthenticated, isSessionLoading } = useSession()
-    // isUserLoading: boolean - Use this for showing loading screens while objects are being loaded
-    const { isUserLoading } = useUser()
-    const navigate = useNavigate()
+    const { isAuthenticated, isSessionLoading } = useSession();
+    const { isUserLoading } = useUser();
+    const navigate = useNavigate();
 
     useEffect(() => {
         if (isAuthenticated) {
-            return navigate("/profile");
+            navigate('/profile');
         }
-    }, [isAuthenticated]) // listen for when isAuthenticated has changed
+    }, [isAuthenticated, navigate]);
+
+    if (isSessionLoading || isUserLoading) {
+        return (
+            <div className="page">
+                <p>Loading...</p>
+            </div>
+        );
+    }
+
+    if (isAuthenticated) {
+        return (
+            <div className="page">
+                <p>Loading...</p>
+            </div>
+        );
+    }
 
     return (
-        <div className='page'>
-            {
-                (isSessionLoading || isUserLoading) && <p>Loading...</p>
-            }
-
-            {!isAuthenticated &&
-                (
-                    <>
-                        <h1 className='title'>Login/SignUp to see the Secret Message!</h1>
-                        <Descope
-                            flowId="sign-up-or-in" 
-                            onSuccess = {(e) => console.log(e.detail.user)}
-                            onError={(e) => console.log('Could not log in!')}
-                            theme="light"
-                        />
-                    </>
-                )
-            }
+        <div className="page">
+            <h1 className="title">Login/SignUp to see the Secret Message!</h1>
+            <Descope
+                flowId="sign-up-or-in"
+                theme="light"
+                onSuccess={(e) => {
+                    console.log(e.detail.user);
+                }}
+                onError={(err) => {
+                    console.log('Error!', err);
+                }}
+            />
         </div>
-    )
+    );
 }
-
 
 export default Login;

--- a/client/src/components/Profile.js
+++ b/client/src/components/Profile.js
@@ -1,76 +1,109 @@
 import '../App.css';
-import { useState, useEffect, useCallback } from "react";
-import { useDescope, useUser, getSessionToken, useSession } from '@descope/react-sdk'
-import { useNavigate } from "react-router-dom";
-import { Link } from "react-router-dom";
-
+import { useState, useEffect, useCallback } from 'react';
+import { useDescope, useUser, getSessionToken, useSession } from '@descope/react-sdk';
+import { useNavigate, Link } from 'react-router-dom';
 
 function Profile() {
-    const { isSessionLoading } = useSession()
-
-    const { user } = useUser()
-    const { logout } = useDescope()
-    const navigate = useNavigate()
+    const { isSessionLoading, isAuthenticated, sessionToken } = useSession();
+    const { user, isUserLoading } = useUser();
+    const { logout } = useDescope();
+    const navigate = useNavigate();
 
     const [secret, setSecret] = useState({
-        secret: "",
-        roles: []
-    })
-
-    const sessionToken = getSessionToken(); // get the session token
+        secret: '',
+        roles: [],
+    });
 
     const logoutUser = useCallback(async () => {
-        await logout()
-        return navigate('/login')
+        await logout();
+        navigate('/login');
     }, [logout, navigate]);
 
     useEffect(() => {
-        fetch('/get_roles', { // call the api endpoint from the flask server
+        if (isSessionLoading || isUserLoading) return;
+        if (!isAuthenticated) {
+            navigate('/login');
+            return;
+        }
+
+        const token = sessionToken || getSessionToken();
+        if (!token) {
+            navigate('/login');
+            return;
+        }
+
+        fetch('/get_roles', {
             headers: {
                 Accept: 'application/json',
-                Authorization: 'Bearer ' + sessionToken,
-            }
-        }).then(data => {
-            if (data.status === 401) {
-                navigate('/login')
-            }
-            return data.json()
-        }).then(jsonData => {
-            setSecret({
-                secret: jsonData.secretMessage,
-                roles: jsonData.roles
-            })
-        }).catch((err) => {
-            console.log(err)
-            navigate('/login')
+                Authorization: `Bearer ${token}`,
+            },
         })
-    }, [])
+            .then((data) => {
+                if (data.status === 401) {
+                    navigate('/login');
+                    return null;
+                }
+                return data.json();
+            })
+            .then((jsonData) => {
+                if (!jsonData) return;
+                setSecret({
+                    secret: jsonData.secretMessage,
+                    roles: jsonData.roles,
+                });
+            })
+            .catch(() => {
+                navigate('/login');
+            });
+    }, [isSessionLoading, isUserLoading, isAuthenticated, sessionToken, navigate]);
+
+    if (isSessionLoading || isUserLoading) {
+        return (
+            <div className="page">
+                <p>Loading...</p>
+            </div>
+        );
+    }
+
+    if (!isAuthenticated || !user) {
+        return null;
+    }
 
     return (
-        <>
-            {user && (
-                <div className='page profile'>
-                    <div>
-                        <h1 className='title'>Hello {user.name} 👋</h1>
-                        <div>My Private Component</div>
-                        <p>Secret Message: <span style={{ padding: "5px 10px", color: "white", backgroundColor: "black" }}>{secret.secret}</span></p>
-                        <p>Your Role(s): </p>
-                        {!secret.roles || secret.roles.length === 0 ?
-                            <p><span style={{ color: "green" }}>No role found!</span></p>
-                            :
-                            secret.roles.map((role, i) => (
-                                <p key={i}><span style={{ color: "green" }}>{role}</span></p>
-                            ))
-                        }
-                        <Link className='link btn' to="/">Home</Link>
-                        <Link className='link btn' to="/dashboard">Dashboard</Link>
-                        <button className='btn' onClick={logoutUser}>Logout</button>
-                    </div>
-                </div>
-            )}
-        </>
-    )
+        <div className="page profile">
+            <div>
+                <h1 className="title">Hello {user.name} 👋</h1>
+                <div>My Private Component</div>
+                <p>
+                    Secret Message:{' '}
+                    <span style={{ padding: '5px 10px', color: 'white', backgroundColor: 'black' }}>
+                        {secret.secret}
+                    </span>
+                </p>
+                <p>Your Role(s): </p>
+                {!secret.roles || secret.roles.length === 0 ? (
+                    <p>
+                        <span style={{ color: 'green' }}>No role found!</span>
+                    </p>
+                ) : (
+                    secret.roles.map((role, i) => (
+                        <p key={i}>
+                            <span style={{ color: 'green' }}>{role}</span>
+                        </p>
+                    ))
+                )}
+                <Link className="link btn" to="/">
+                    Home
+                </Link>
+                <Link className="link btn" to="/dashboard">
+                    Dashboard
+                </Link>
+                <button className="btn" type="button" onClick={logoutUser}>
+                    Logout
+                </button>
+            </div>
+        </div>
+    );
 }
-
 
 export default Profile;

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -3,17 +3,28 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
-import { AuthProvider } from '@descope/react-sdk'
+import { AuthProvider } from '@descope/react-sdk';
+import ConfigError, { isValidDescopeProjectId } from './ConfigError';
 
+const projectId = process.env.REACT_APP_PROJECT_ID;
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(
-  <React.StrictMode>
-    <AuthProvider projectId={process.env.REACT_APP_PROJECT_ID}>
-      <App />
-    </AuthProvider>
-  </React.StrictMode>
-);
+
+if (!isValidDescopeProjectId(projectId)) {
+  root.render(
+    <React.StrictMode>
+      <ConfigError />
+    </React.StrictMode>
+  );
+} else {
+  root.render(
+    <React.StrictMode>
+      <AuthProvider projectId={projectId.trim()}>
+        <App />
+      </AuthProvider>
+    </React.StrictMode>
+  );
+}
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))


### PR DESCRIPTION
- Upgrade @descope/react-sdk to ^2.x; repair Login (Descope component, single AuthProvider)
- Profile/Dashboard: gate API calls on session; use sessionToken from useSession with getSessionToken fallback
- Home: Navigate when authenticated; loading and iframe titles
- index: validate REACT_APP_PROJECT_ID before AuthProvider to avoid blank screen crash
- Add ConfigError screen for missing or placeholder project ID